### PR TITLE
Update for SV 1.4 and SMAPI 3.0

### DIFF
--- a/ShipEverything/Main.cs
+++ b/ShipEverything/Main.cs
@@ -33,14 +33,14 @@ namespace ShipEverything {
          }
          public static class ShippingMenu {
             public class SVObjectEx : StardewValley.Object {
-               public delegate void drawInMenuDelegate(SpriteBatch spriteBatch, Vector2 location, Single scaleSize, Single transparency, Single layerDepth, Boolean drawStackNumber, Color color, Boolean drawShadow);
+               public delegate void drawInMenuDelegate(SpriteBatch spriteBatch, Vector2 location, Single scaleSize, Single transparency, Single layerDepth, StardewValley.StackDrawType drawStackNumber, Color color, Boolean drawShadow);
                private drawInMenuDelegate orgCall;
                public SVObjectEx(StardewValley.Item item) : base() {
                   var salePrice = Math.Max(1, item.salePrice());
                   orgCall = new drawInMenuDelegate(item.drawInMenu);
                   this.Category = item.Category;
                   this.DisplayName = item.DisplayName;
-                  this.hasBeenInInventory = item.hasBeenInInventory;
+                  this.HasBeenInInventory = item.HasBeenInInventory;
                   this.Name = item.Name;
                   this.ParentSheetIndex = item.ParentSheetIndex;
                   this.Price = salePrice;
@@ -48,12 +48,12 @@ namespace ShipEverything {
                   this.SpecialVariable = item.SpecialVariable;
                }
 
-               public override void drawInMenu(SpriteBatch spriteBatch, Vector2 location, Single scaleSize, Single transparency, Single layerDepth, Boolean drawStackNumber, Color color, Boolean drawShadow) {
+               public override void drawInMenu(SpriteBatch spriteBatch, Vector2 location, Single scaleSize, Single transparency, Single layerDepth, StardewValley.StackDrawType drawStackNumber, Color color, Boolean drawShadow) {
                   orgCall(spriteBatch, location, scaleSize, transparency, layerDepth, drawStackNumber, color, drawShadow);
                }
             }
             public static void postfix_parseItems(IList<StardewValley.Item> items,
-               ref List<List<StardewValley.Item>> ___categoryItems, ref List<Int32> ___categoryTotals, ref List<MoneyDial> ___categoryDials) {
+               ref List<List<StardewValley.Item>> ___categoryItems, ref List<Int32> ___categoryTotals, ref List<MoneyDial> ___categoryDials, ref Dictionary<StardewValley.Item, int> ___itemValues) {
                Int32 gainedMoney = 0;
                foreach (var item in items) {
                   if (!(item is StardewValley.Object)) {
@@ -64,6 +64,7 @@ namespace ShipEverything {
                      ___categoryTotals[4] += salePrice;
                      ___categoryTotals[5] += salePrice;
                      ___categoryDials[4].previousTargetValue = ___categoryDials[4].currentValue = ___categoryTotals[4];
+                     ___itemValues[_obj] = salePrice;
                      gainedMoney += salePrice;
                      StardewValley.Game1.stats.itemsShipped += 1;
                   }

--- a/ShipEverything/ShipEverything.csproj
+++ b/ShipEverything/ShipEverything.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -71,15 +72,12 @@
     <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/ShipEverything/manifest.json
+++ b/ShipEverything/manifest.json
@@ -1,7 +1,7 @@
 {
    "Name": "ShipEverything",
    "Author": "Berkay Yigit (berkay2578)",
-   "Version": "1.0.0",
+   "Version": "1.0.1",
    "Description": "Allows you to put anything into the shipping bin.",
    "UniqueID": "berkay2578.ShipEverything",
    "EntryDll": "ShipEverything.dll",

--- a/ShipEverything/packages.config
+++ b/ShipEverything/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Lib.Harmony" version="1.2.0.1" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Updated to SMAPI 3.0.
Updated method signatures/member names for SV 1.4.
Updated version in manifest.json.
Changed build to x86 to prevent compiler warnings.
Add items to itemValues dictionary to prevent crash when pressing '+' to inspect the contents of a category on the end-of-day ShippingMenu screen.